### PR TITLE
Fix yokogawa_to_zarr multiple-imread-calls bug

### DIFF
--- a/fractal/tasks/create_zarr_structure.py
+++ b/fractal/tasks/create_zarr_structure.py
@@ -354,6 +354,11 @@ def create_zarr_structure(
             group_tables = group_FOV.create_group("tables/")  # noqa: F841
             write_elem(group_tables, "FOV_ROI_table", FOV_ROIs_table)
 
+    # FIXME: is this needed?
+    for zarrurl in zarrurls["plate"] + zarrurls["well"]:
+        if not os.path.isdir(zarrurl):
+            raise FileNotFoundError(f"Missing file {zarrurl}")
+
     return zarrurls, actual_channels
 
 

--- a/fractal/tasks/create_zarr_structure.py
+++ b/fractal/tasks/create_zarr_structure.py
@@ -358,6 +358,7 @@ def create_zarr_structure(
     for zarrurl in zarrurls["plate"] + zarrurls["well"]:
         if not os.path.isdir(zarrurl):
             raise FileNotFoundError(f"Missing file {zarrurl}")
+    print("All files in zarrurls are there")
 
     return zarrurls, actual_channels
 

--- a/fractal/tasks/yokogawa_to_zarr.py
+++ b/fractal/tasks/yokogawa_to_zarr.py
@@ -16,9 +16,10 @@ import re
 from glob import glob
 
 import dask.array as da
-import numpy as np
 from dask import delayed
 from skimage.io import imread
+
+from fractal.tasks.lib_pyramid_creation import write_pyramid
 
 
 def sort_fun(s):
@@ -86,16 +87,13 @@ def yokogawa_to_zarr(
     well_column = zarrurl.split("/")[-3]
     well_ID = well_row + well_column
 
-    lazy_imread = delayed(imread)
-    fc_list = {level: [] for level in range(num_levels)}
+    delayed_imread = delayed(imread)
 
     print(f"Channels: {chl_list}")
 
+    list_channels = []
     for chl in chl_list:
         A, C = chl.split("_")
-
-        l_rows = []
-        data_zfyx = []
 
         print(zarrurl, well_ID)
         glob_path = f"{in_path}*_{well_ID}_*{A}*{C}.{ext}"
@@ -119,75 +117,47 @@ def yokogawa_to_zarr(
 
         sample = imread(filenames[0])
 
+        # Loop over FOVs, corresponding to filenames[start:end]
         start = 0
         end = int(max_z)
-
-        for ro in range(int(rows)):
-            cell = []
-            for co in range(int(cols)):
-                lazy_arrays = [lazy_imread(fn) for fn in filenames[start:end]]
+        data_zfyx = []
+        for row in range(int(rows)):
+            FOV_rows = []
+            for col in range(int(cols)):
+                images = [delayed_imread(fn) for fn in filenames[start:end]]
+                lazy_images = [
+                    da.from_delayed(
+                        image, shape=sample.shape, dtype=sample.dtype
+                    )
+                    for image in images
+                ]
+                z_stack = da.stack(lazy_images, axis=0)
                 start += int(max_z)
                 end += int(max_z)
-                dask_arrays = [
-                    da.from_delayed(
-                        delayed_reader, shape=sample.shape, dtype=sample.dtype
-                    )
-                    for delayed_reader in lazy_arrays
-                ]
-                z_stack = da.stack(dask_arrays, axis=0)
-                cell.append(z_stack)
-            l_rows = da.block(cell)
-            data_zfyx.append(l_rows)
-        data_zyx = da.concatenate(data_zfyx, axis=1).rechunk(
-            {1: chunk_size_y, 2: chunk_size_x}, balance=True
-        )
+                FOV_rows.append(z_stack)
+            data_zfyx.append(da.block(FOV_rows))
+        # Remove FOV index
+        data_zyx = da.concatenate(data_zfyx, axis=1)
+        list_channels.append(data_zyx)
+    data_czyx = da.stack(list_channels, axis=0)
 
-        # Define coarsening options
-        f_matrices = {}
-        for level in range(num_levels):
-            if level == 0:
-                f_matrices[level] = data_zyx
-            else:
-                if min(f_matrices[level - 1].shape[1:]) < coarsening_xy:
-                    raise Exception(
-                        f"ERROR at pyramid level={level}: "
-                        f"coarsening_xy={coarsening_xy} but "
-                        f"level={level-1} has shape "
-                        f"{f_matrices[level - 1].shape}"
-                    )
-                f_matrices[level] = da.coarsen(
-                    np.mean,
-                    f_matrices[level - 1],
-                    {1: coarsening_xy, 2: coarsening_xy},
-                    trim_excess=True,
-                ).rechunk(
-                    {
-                        1: chunk_size_y,
-                        2: chunk_size_x,
-                    },
-                    balance=True,
-                )
-            fc_list[level].append(f_matrices[level].astype(sample.dtype))
+    if delete_input:
+        for f in filenames:
+            try:
+                os.remove(f)
+            except OSError as e:
+                print("Error: %s : %s" % (f, e.strerror))
 
-        if delete_input:
-            for f in filenames:
-                try:
-                    os.remove(f)
-                except OSError as e:
-                    print("Error: %s : %s" % (f, e.strerror))
-
-    level_data = [
-        da.stack(fc_list[level], axis=0) for level in range(num_levels)
-    ]
-
-    shape_list = []
-    for i, level in enumerate(level_data):
-        level.to_zarr(zarrurl + f"{i}/", dimension_separator="/")
-        print(f"Chunks at level {i}:\n", level.chunks)
-        shape_list.append(level.shape)
-    print()
-
-    return shape_list
+    # Construct resolution pyramid
+    write_pyramid(
+        data_czyx,
+        newzarrurl=zarrurl,
+        overwrite=False,
+        coarsening_xy=coarsening_xy,
+        num_levels=num_levels,
+        chunk_size_x=chunk_size_x,
+        chunk_size_y=chunk_size_y,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_unit_yokogawa_to_zarr.py
+++ b/tests/test_unit_yokogawa_to_zarr.py
@@ -76,8 +76,8 @@ def test_yokogawa_to_zarr(
 
     # Read number of calls to imread
     num_calls_imread = np.loadtxt(logfile, dtype=int).sum()
-    # Subtract one, for the dummy call at the beginning of the task (used to
-    # determine shape and dtype)
-    num_calls_imread -= 1
+    # Subtract one for each channel, for the dummy call at the beginning of
+    # the task (used to determine shape and dtype)
+    num_calls_imread -= len(chl_list)
 
     assert num_calls_imread == len(images)

--- a/tests/test_unit_yokogawa_to_zarr.py
+++ b/tests/test_unit_yokogawa_to_zarr.py
@@ -20,6 +20,8 @@ from pytest import MonkeyPatch
 from fractal.tasks.yokogawa_to_zarr import yokogawa_to_zarr
 
 
+# FIXME: try with two channels
+
 images = [
     "plate_well_T0001F001L01A01Z01C01.png",
     "plate_well_T0001F002L01A01Z01C01.png",
@@ -27,7 +29,7 @@ images = [
     "plate_well_T0001F004L01A01Z01C01.png",
 ]
 
-chl_list = ["01"]
+chl_list = ["A01_C01"]
 num_levels = 5
 coarsening_factor_xy = 2
 coarsening_factor_z = 1


### PR DESCRIPTION
Fixes yokogawa_to_zarr task, by using the `write_pyramid` function.
Before this PR, the underlying array-construction functions (i.e. `imread`, in this case) were called once for each pyramid level.

Closes #97 