### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -507,20 +507,20 @@ files = [
 
 [[package]]
 name = "deprecated"
-version = "1.2.14"
+version = "1.2.15"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 files = [
-    {file = "Deprecated-1.2.14-py2.py3-none-any.whl", hash = "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c"},
-    {file = "Deprecated-1.2.14.tar.gz", hash = "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"},
+    {file = "Deprecated-1.2.15-py2.py3-none-any.whl", hash = "sha256:353bc4a8ac4bfc96800ddab349d89c25dec1079f65fd53acdcc1e0b975b21320"},
+    {file = "deprecated-1.2.15.tar.gz", hash = "sha256:683e561a90de76239796e6b6feac66b99030d2dd3fcf61ef996330f14bbb9b0d"},
 ]
 
 [package.dependencies]
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
+dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "jinja2 (>=3.0.3,<3.1.0)", "setuptools", "sphinx (<2)", "tox"]
 
 [[package]]
 name = "devtools"
@@ -696,7 +696,7 @@ typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "fractal-server"
-version = "2.9.0a3"
+version = "2.9.0a4"
 description = "Server component of the Fractal analytics platform"
 optional = false
 python-versions = "^3.10"
@@ -726,7 +726,7 @@ uvicorn-worker = "^0.2.0"
 type = "git"
 url = "https://github.com/fractal-analytics-platform/fractal-server.git"
 reference = "main"
-resolved_reference = "cc03c91805d5a54befd712b7c0a28acb6a00a424"
+resolved_reference = "87c2868d73e458273beca7895d51763366ed5847"
 
 [[package]]
 name = "ghp-import"
@@ -879,13 +879,13 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.6"
+version = "1.0.7"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.6-py3-none-any.whl", hash = "sha256:27b59625743b85577a8c0e10e55b50b5368a4f2cfe8cc7bcfa9cf00829c2682f"},
-    {file = "httpcore-1.0.6.tar.gz", hash = "sha256:73f6dbd6eb8c21bbf7ef8efad555481853f5f6acdeaff1edb0694289269ee17f"},
+    {file = "httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd"},
+    {file = "httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c"},
 ]
 
 [package.dependencies]
@@ -2158,13 +2158,13 @@ SQLAlchemy = ">=2.0.14,<2.1.0"
 
 [[package]]
 name = "starlette"
-version = "0.41.2"
+version = "0.41.3"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "starlette-0.41.2-py3-none-any.whl", hash = "sha256:fbc189474b4731cf30fcef52f18a8d070e3f3b46c6a04c97579e85e6ffca942d"},
-    {file = "starlette-0.41.2.tar.gz", hash = "sha256:9834fd799d1a87fd346deb76158668cfa0b0d56f85caefe8268e2d97c3468b62"},
+    {file = "starlette-0.41.3-py3-none-any.whl", hash = "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7"},
+    {file = "starlette-0.41.3.tar.gz", hash = "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 4 updates, 0 removals

  - Updating httpcore (1.0.6 -> 1.0.7)
  - Updating starlette (0.41.2 -> 0.41.3)
  - Updating deprecated (1.2.14 -> 1.2.15)
  - Updating fractal-server (2.9.0a3 cc03c91 -> 2.9.0a4 87c2868)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
bcrypt           4.0.1           4.2.0           Modern password hashing for...
bumpver          2022.1120       2024.1130       Bump version numbers in pro...
cloudpickle      3.0.0           3.1.0           Pickler class to extend the...
coverage         6.5.0           7.6.7           Code coverage measurement f...
deprecated       1.2.14          1.2.15          Python @deprecated decorato...
email-validator  2.1.2           2.2.0           A robust email address synt...
fastapi-users    12.1.3          14.0.0          Ready-to-use and customizab...
fractal-server   2.9.0a3 cc03c91 2.9.0a4 87c2868 Server component of the Fra...
gunicorn         22.0.0          23.0.0          WSGI HTTP Server for UNIX
httpcore         1.0.6           1.0.7           A minimal low-level HTTP cl...
packaging        23.2            24.2            Core utilities for Python p...
pre-commit       2.21.0          4.0.1           A framework for managing an...
psutil           5.9.8           6.1.0           Cross-platform lib for proc...
pydantic         1.10.19         2.9.2           Data validation and setting...
pyjwt            2.8.0           2.10.0          JSON Web Token implementati...
pytest           7.4.4           8.3.3           pytest: simple powerful tes...
python-multipart 0.0.7           0.0.17          A streaming multipart parse...
sqlmodel         0.0.21          0.0.22          SQLModel, SQL databases in ...
starlette        0.41.2          0.41.3          The little ASGI library tha...
uvicorn          0.29.0          0.32.0          The lightning-fast ASGI ser...
```

### Outdated dependencies _after_ PR:

```bash
bcrypt           4.0.1     4.2.0     Modern password hashing for your softwa...
bumpver          2022.1120 2024.1130 Bump version numbers in project files.
cloudpickle      3.0.0     3.1.0     Pickler class to extend the standard pi...
coverage         6.5.0     7.6.7     Code coverage measurement for Python
email-validator  2.1.2     2.2.0     A robust email address syntax and deliv...
fastapi-users    12.1.3    14.0.0    Ready-to-use and customizable users man...
gunicorn         22.0.0    23.0.0    WSGI HTTP Server for UNIX
packaging        23.2      24.2      Core utilities for Python packages
pre-commit       2.21.0    4.0.1     A framework for managing and maintainin...
psutil           5.9.8     6.1.0     Cross-platform lib for process and syst...
pydantic         1.10.19   2.9.2     Data validation and settings management...
pyjwt            2.8.0     2.10.0    JSON Web Token implementation in Python
pytest           7.4.4     8.3.3     pytest: simple powerful testing with Py...
python-multipart 0.0.7     0.0.17    A streaming multipart parser for Python
sqlmodel         0.0.21    0.0.22    SQLModel, SQL databases in Python, desi...
uvicorn          0.29.0    0.32.0    The lightning-fast ASGI server.
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._