### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -21,24 +21,24 @@ tz = ["backports.zoneinfo"]
 
 [[package]]
 name = "anyio"
-version = "4.6.2.post1"
+version = "4.7.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"},
-    {file = "anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c"},
+    {file = "anyio-4.7.0-py3-none-any.whl", hash = "sha256:ea60c3723ab42ba6fff7e8ccb0488c898ec538ff4df1f1d5e642c3601d07e352"},
+    {file = "anyio-4.7.0.tar.gz", hash = "sha256:2f834749c602966b7d456a7567cafcb309f96482b5081d14ac93ccd457f9dd48"},
 ]
 
 [package.dependencies]
 exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
-typing-extensions = {version = ">=4.1", markers = "python_version < \"3.11\""}
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
-doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21.0b1)"]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21)"]
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
@@ -759,7 +759,7 @@ typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "fractal-server"
-version = "2.10.0a0"
+version = "2.10.0"
 description = "Server component of the Fractal analytics platform"
 optional = false
 python-versions = "^3.10"
@@ -788,7 +788,7 @@ uvicorn-worker = "^0.2.0"
 type = "git"
 url = "https://github.com/fractal-analytics-platform/fractal-server.git"
 reference = "main"
-resolved_reference = "28472d010d8f88a116a6a0d844ef4728073824cb"
+resolved_reference = "87e8a20575778a8dc215e0f21e7f6434fef8d7ed"
 
 [[package]]
 name = "ghp-import"
@@ -987,17 +987,17 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "httpx-oauth"
-version = "0.15.1"
+version = "0.16.0"
 description = "Async OAuth client using HTTPX"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "httpx_oauth-0.15.1-py3-none-any.whl", hash = "sha256:89b45f250e93e42bbe9631adf349cab0e3d3ced958c07e06651735198d1bdf00"},
-    {file = "httpx_oauth-0.15.1.tar.gz", hash = "sha256:4094cf0938fc7252b5f5dfd62cd1ab5aee2fcb6734e621942ee17d1af4806b74"},
+    {file = "httpx_oauth-0.16.0-py3-none-any.whl", hash = "sha256:4394a5e60cb66fd6e14031d41be8e4060580c553422a641b624ade0f33d0df04"},
+    {file = "httpx_oauth-0.16.0.tar.gz", hash = "sha256:5ce4696e4c9572711fb558808f7436afd7712db825c56b0f4f430e16c649f136"},
 ]
 
 [package.dependencies]
-httpx = ">=0.18,<1.0.0"
+httpx = ">=0.18,<0.28"
 
 [[package]]
 name = "identify"
@@ -1090,13 +1090,13 @@ files = [
 
 [[package]]
 name = "mako"
-version = "1.3.7"
+version = "1.3.8"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Mako-1.3.7-py3-none-any.whl", hash = "sha256:d18f990ad57f800ce8e76cbfb0b74afe471c293517e9f5003ace6dad5aa72c36"},
-    {file = "mako-1.3.7.tar.gz", hash = "sha256:20405b1232e0759f0e7d87b01f6bb94fce0761747f1cb876ecf90bd512d0b639"},
+    {file = "Mako-1.3.8-py3-none-any.whl", hash = "sha256:42f48953c7eb91332040ff567eb7eea69b22e7a4affbc5ba8e845e8f730f6627"},
+    {file = "mako-1.3.8.tar.gz", hash = "sha256:577b97e414580d3e088d47c2dbbe9594aa7a5146ed2875d4dfa9075af2dd3cc8"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 4 updates, 0 removals

  - Updating anyio (4.6.2.post1 -> 4.7.0)
  - Updating httpx-oauth (0.15.1 -> 0.16.0)
  - Updating mako (1.3.7 -> 1.3.8)
  - Updating fractal-server (2.10.0a0 28472d0 -> 2.10.0 87e8a20)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
anyio            4.6.2.post1      4.7.0          High level compatibility la...
asttokens        2.4.1            3.0.0          Annotate AST trees with sou...
bumpver          2022.1120        2024.1130      Bump version numbers in pro...
cloudpickle      3.0.0            3.1.0          Pickler class to extend the...
coverage         6.5.0            7.6.9          Code coverage measurement f...
fractal-server   2.10.0a0 28472d0 2.10.0 87e8a20 Server component of the Fra...
gunicorn         22.0.0           23.0.0         WSGI HTTP Server for UNIX
httpx            0.27.2           0.28.1         The next generation HTTP cl...
httpx-oauth      0.15.1           0.16.0         Async OAuth client using HTTPX
mako             1.3.7            1.3.8          A super-fast templating lan...
packaging        23.2             24.2           Core utilities for Python p...
pre-commit       3.8.0            4.0.1          A framework for managing an...
psutil           5.9.8            6.1.0          Cross-platform lib for proc...
pydantic         1.10.19          2.10.3         Data validation and setting...
pyjwt            2.9.0            2.10.1         JSON Web Token implementati...
pytest           7.4.4            8.3.4          pytest: simple powerful tes...
python-multipart 0.0.17           0.0.19         A streaming multipart parse...
sqlmodel         0.0.21           0.0.22         SQLModel, SQL databases in ...
uvicorn          0.29.0           0.32.1         The lightning-fast ASGI ser...
```

### Outdated dependencies _after_ PR:

```bash
asttokens        2.4.1     3.0.0     Annotate AST trees with source code pos...
bumpver          2022.1120 2024.1130 Bump version numbers in project files.
cloudpickle      3.0.0     3.1.0     Pickler class to extend the standard pi...
coverage         6.5.0     7.6.9     Code coverage measurement for Python
gunicorn         22.0.0    23.0.0    WSGI HTTP Server for UNIX
httpx            0.27.2    0.28.1    The next generation HTTP client.
packaging        23.2      24.2      Core utilities for Python packages
pre-commit       3.8.0     4.0.1     A framework for managing and maintainin...
psutil           5.9.8     6.1.0     Cross-platform lib for process and syst...
pydantic         1.10.19   2.10.3    Data validation and settings management...
pyjwt            2.9.0     2.10.1    JSON Web Token implementation in Python
pytest           7.4.4     8.3.4     pytest: simple powerful testing with Py...
python-multipart 0.0.17    0.0.19    A streaming multipart parser for Python
sqlmodel         0.0.21    0.0.22    SQLModel, SQL databases in Python, desi...
uvicorn          0.29.0    0.32.1    The lightning-fast ASGI server.
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._