### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -390,13 +390,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.7"
+version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
+    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
+    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
 ]
 
 [package.dependencies]
@@ -768,6 +768,7 @@ develop = false
 alembic = "^1.13.1"
 cloudpickle = ">=3.0.0,<3.1.0"
 clusterfutures = "^0.5"
+cryptography = ">=44.0.0,<44.1.0"
 fabric = "^3.2.2"
 fastapi = "^0.115.0"
 fastapi-users = {version = ">=14,<15", extras = ["oauth"]}
@@ -786,7 +787,7 @@ uvicorn-worker = "^0.2.0"
 type = "git"
 url = "https://github.com/fractal-analytics-platform/fractal-server.git"
 reference = "main"
-resolved_reference = "f89f2d62fa8a63e8101510cd411bd62e5107def6"
+resolved_reference = "fff51a3ce857da0fa170f02df7dba273bd22843a"
 
 [[package]]
 name = "ghp-import"
@@ -985,17 +986,17 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "httpx-oauth"
-version = "0.16.0"
+version = "0.16.1"
 description = "Async OAuth client using HTTPX"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "httpx_oauth-0.16.0-py3-none-any.whl", hash = "sha256:4394a5e60cb66fd6e14031d41be8e4060580c553422a641b624ade0f33d0df04"},
-    {file = "httpx_oauth-0.16.0.tar.gz", hash = "sha256:5ce4696e4c9572711fb558808f7436afd7712db825c56b0f4f430e16c649f136"},
+    {file = "httpx_oauth-0.16.1-py3-none-any.whl", hash = "sha256:2fcad82f80f28d0473a0fc4b4eda223dc952050af7e3a8c8781342d850f09fb5"},
+    {file = "httpx_oauth-0.16.1.tar.gz", hash = "sha256:7402f061f860abc092ea4f5c90acfc576a40bbb79633c1d2920f1ca282c296ee"},
 ]
 
 [package.dependencies]
-httpx = ">=0.18,<0.28"
+httpx = ">=0.18"
 
 [[package]]
 name = "identify"
@@ -1049,13 +1050,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.5"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
-    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
+    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
+    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
 ]
 
 [package.dependencies]
@@ -1743,13 +1744,13 @@ tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.12"
+version = "10.13"
 description = "Extension pack for Python Markdown."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pymdown_extensions-10.12-py3-none-any.whl", hash = "sha256:49f81412242d3527b8b4967b990df395c89563043bc51a3d2d7d500e52123b77"},
-    {file = "pymdown_extensions-10.12.tar.gz", hash = "sha256:b0ee1e0b2bef1071a47891ab17003bfe5bf824a398e13f49f8ed653b699369a7"},
+    {file = "pymdown_extensions-10.13-py3-none-any.whl", hash = "sha256:80bc33d715eec68e683e04298946d47d78c7739e79d808203df278ee8ef89428"},
+    {file = "pymdown_extensions-10.13.tar.gz", hash = "sha256:e0b351494dc0d8d14a1f52b39b1499a00ef1566b4ba23dc74f1eba75c736f5dd"},
 ]
 
 [package.dependencies]
@@ -2305,13 +2306,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.3"
+version = "2.3.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
-    {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
+    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
+    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
 ]
 
 [package.extras]


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 3 updates, 0 removals

  - Updating click (8.1.7 -> 8.1.8)
  - Updating httpx-oauth (0.16.0 -> 0.16.1)
  - Updating fractal-server (2.10.2 f89f2d6 -> 2.10.2 fff51a3)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
asttokens        2.4.1          3.0.0          Annotate AST trees with sourc...
bumpver          2022.1120      2024.1130      Bump version numbers in proje...
click            8.1.7          8.1.8          Composable command line inter...
cloudpickle      3.0.0          3.1.0          Pickler class to extend the s...
coverage         6.5.0          7.6.9          Code coverage measurement for...
fractal-server   2.10.2 f89f2d6 2.10.2 fff51a3 Server component of the Fract...
gunicorn         22.0.0         23.0.0         WSGI HTTP Server for UNIX
httpx            0.27.2         0.28.1         The next generation HTTP client.
httpx-oauth      0.16.0         0.16.1         Async OAuth client using HTTPX
packaging        23.2           24.2           Core utilities for Python pac...
pre-commit       3.8.0          4.0.1          A framework for managing and ...
psutil           5.9.8          6.1.1          Cross-platform lib for proces...
pydantic         1.10.19        2.10.4         Data validation and settings ...
pyjwt            2.9.0          2.10.1         JSON Web Token implementation...
pytest           7.4.4          8.3.4          pytest: simple powerful testi...
python-multipart 0.0.17         0.0.20         A streaming multipart parser ...
sqlmodel         0.0.21         0.0.22         SQLModel, SQL databases in Py...
starlette        0.41.3         0.42.0         The little ASGI library that ...
uvicorn          0.29.0         0.34.0         The lightning-fast ASGI server.
```

### Outdated dependencies _after_ PR:

```bash
asttokens        2.4.1     3.0.0     Annotate AST trees with source code pos...
bumpver          2022.1120 2024.1130 Bump version numbers in project files.
cloudpickle      3.0.0     3.1.0     Pickler class to extend the standard pi...
coverage         6.5.0     7.6.9     Code coverage measurement for Python
gunicorn         22.0.0    23.0.0    WSGI HTTP Server for UNIX
httpx            0.27.2    0.28.1    The next generation HTTP client.
packaging        23.2      24.2      Core utilities for Python packages
pre-commit       3.8.0     4.0.1     A framework for managing and maintainin...
psutil           5.9.8     6.1.1     Cross-platform lib for process and syst...
pydantic         1.10.19   2.10.4    Data validation and settings management...
pyjwt            2.9.0     2.10.1    JSON Web Token implementation in Python
pytest           7.4.4     8.3.4     pytest: simple powerful testing with Py...
python-multipart 0.0.17    0.0.20    A streaming multipart parser for Python
sqlmodel         0.0.21    0.0.22    SQLModel, SQL databases in Python, desi...
starlette        0.41.3    0.42.0    The little ASGI library that shines.
uvicorn          0.29.0    0.34.0    The lightning-fast ASGI server.
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._