### PR TITLE
`fractal auth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 # 2.24.0 (unreleased)
 
 * Commands:
-    * Review authentication flow, including interactively prompting for a token (\#924, \#929).
+    * Review authentication flow for standard `fractal` commands, including interactively prompting for a token (\#924, \#929).
+    * Introduce `fractal auth {check-token,set-token,clear-token}` commands (\#931).
     * Support `FRACTAL_WEB` configuration variable (\#924, \#930).
     * Include hint about where to find a valid token (\#930).
 * Internal:

--- a/src/fractal_client/cmd/__init__.py
+++ b/src/fractal_client/cmd/__init__.py
@@ -5,6 +5,9 @@ from fractal_client import __VERSION__
 from fractal_client.auth._client import AuthClient
 from fractal_client.interface import Interface
 
+from ._auth import auth_check_token
+from ._auth import auth_clear_token
+from ._auth import auth_set_token
 from ._dataset import delete_dataset
 from ._dataset import get_dataset
 from ._dataset import patch_dataset
@@ -476,4 +479,22 @@ def template(
     else:
         raise NoCommandError(f"Command 'template {subcmd}' not found")
 
+    return iface
+
+
+def auth(*, subcmd: str, **kwargs) -> Interface:
+    if subcmd == "check-token":
+        parameters = ["fractal_server", "token_path"]
+        function_kwargs = get_kwargs(parameters, kwargs)
+        iface = auth_check_token(**function_kwargs)
+    elif subcmd == "set-token":
+        parameters = ["token_path"]
+        function_kwargs = get_kwargs(parameters, kwargs)
+        iface = auth_set_token(**function_kwargs)
+    elif subcmd == "clear-token":
+        parameters = ["token_path"]
+        function_kwargs = get_kwargs(parameters, kwargs)
+        iface = auth_clear_token(**function_kwargs)
+    else:
+        raise NoCommandError(f"Command 'auth {subcmd}' not found")
     return iface

--- a/src/fractal_client/cmd/_auth.py
+++ b/src/fractal_client/cmd/_auth.py
@@ -46,12 +46,12 @@ def auth_set_token(*, token_path: str | None) -> Interface:
         path.write_text(token)
         return Interface(
             retcode=0,
-            data=f"Token written to {path}",
+            data=f"Token written to {path}.",
         )
     else:
         return Interface(
             retcode=1,
-            data="The token provided is invalid or expired/expiring.",
+            data="The token provided is invalid or expired/expiring. Exit.",
         )
 
 

--- a/src/fractal_client/cmd/_auth.py
+++ b/src/fractal_client/cmd/_auth.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-from typing import Any
 
 from httpx2 import Client
 from httpx2._models import Response
@@ -9,21 +8,32 @@ from fractal_client.auth._token_utils import _get_token_hint
 from fractal_client.auth._token_utils import _is_token_valid
 from fractal_client.config import settings
 from fractal_client.interface import Interface
-from fractal_client.response import check_response
 
 
 def auth_check_token(*, fractal_server: str, token_path: str | None) -> Interface:
     path = Path(token_path or settings.default_token_path)
     if not path.exists():
-        sys.exit(f"File not found at {path}")
+        sys.exit(f"File not found at {path}.")
     token = Path(path).read_text().strip()
-    with Client() as client:
-        url = f"{fractal_server}/auth/current-user/"
-        res: Response = client.get(url, headers={"Authorization": f"Bearer {token}"})
-        user: dict[str, Any] = check_response(res, expected_status_code=200)
-        user_email = user["email"]
-
-    return Interface(retcode=0, data=f"Valid token for {user_email} found at {path}")
+    try:
+        with Client() as client:
+            url = f"{fractal_server}/auth/current-user/"
+            res: Response = client.get(
+                url, headers={"Authorization": f"Bearer {token}"}
+            )
+            if res.status_code != 200:
+                raise ValueError(f"Server responded with {res}")
+            user = res.json()
+            user_email = user["email"]
+        return Interface(
+            retcode=0,
+            data=f"Valid token for {user_email} found at {path}.",
+        )
+    except Exception as e:
+        return Interface(
+            retcode=1,
+            data=f"Token verification failed. Original error: {str(e)}",
+        )
 
 
 def auth_set_token(*, token_path: str | None) -> Interface:
@@ -34,19 +44,27 @@ def auth_set_token(*, token_path: str | None) -> Interface:
     if _is_token_valid(token):
         path.parent.mkdir(exist_ok=True, parents=True)
         path.write_text(token)
+        return Interface(
+            retcode=0,
+            data=f"Token written to {path}",
+        )
     else:
         return Interface(
             retcode=1,
             data="The token provided is invalid or expired/expiring.",
         )
 
-    return Interface(retcode=0, data="")
-
 
 def auth_clear_token(*, token_path: str | None) -> Interface:
     path = Path(token_path or settings.default_token_path)
     if path.exists():
         path.unlink()
-        return Interface(retcode=0, data=f"Removed {path}.")
+        return Interface(
+            retcode=0,
+            data=f"Removed {path}.",
+        )
     else:
-        return Interface(retcode=1, data=f"File not found at {path}, exit.")
+        return Interface(
+            retcode=1,
+            data=f"File not found at {path}, exit.",
+        )

--- a/src/fractal_client/cmd/_auth.py
+++ b/src/fractal_client/cmd/_auth.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+from typing import Any
+
+from httpx2 import Client
+from httpx2._models import Response
+
+from fractal_client.auth._token_utils import _get_token_hint
+from fractal_client.auth._token_utils import _is_token_valid
+from fractal_client.config import settings
+from fractal_client.interface import Interface
+from fractal_client.response import check_response
+
+
+def auth_check_token(*, fractal_server: str, token_path: str | None) -> Interface:
+    path = Path(token_path or settings.default_token_path)
+    if not path.exists():
+        sys.exit(f"File not found at {path}")
+    token = Path(path).read_text().strip()
+    with Client() as client:
+        url = f"{fractal_server}/auth/current-user/"
+        res: Response = client.get(url, headers={"Authorization": f"Bearer {token}"})
+        user: dict[str, Any] = check_response(res, expected_status_code=200)
+        user_email = user["email"]
+
+    return Interface(retcode=0, data=f"Valid token for {user_email} found at {path}")
+
+
+def auth_set_token(*, token_path: str | None) -> Interface:
+    path = Path(token_path or settings.default_token_path)
+    hint = _get_token_hint()
+    prompt_msg = f"Paste a valid token here{hint}, and it will be written to {path}: "
+    token = input(prompt_msg).strip()
+    if _is_token_valid(token):
+        path.parent.mkdir(exist_ok=True, parents=True)
+        path.write_text(token)
+    else:
+        return Interface(
+            retcode=1,
+            data="The token provided is invalid or expired/expiring.",
+        )
+
+    return Interface(retcode=0, data="")
+
+
+def auth_clear_token(*, token_path: str | None) -> Interface:
+    path = Path(token_path or settings.default_token_path)
+    if path.exists():
+        path.unlink()
+        return Interface(retcode=0, data=f"Removed {path}.")
+    else:
+        return Interface(retcode=1, data=f"File not found at {path}, exit.")

--- a/src/fractal_client/main.py
+++ b/src/fractal_client/main.py
@@ -64,6 +64,10 @@ def handle(cli_args: list[str]) -> Interface:
     try:
         if args.cmd == "version":
             interface = cmd_handler(fractal_server)
+        elif args.cmd == "auth":
+            kwargs = vars(args).copy()
+            kwargs.pop("fractal_server")
+            interface = cmd_handler(fractal_server=fractal_server, **kwargs)
         else:
             auth_info: AuthInfo = get_auth_info(args=args)
             with AuthClient(

--- a/src/fractal_client/parser/__init__.py
+++ b/src/fractal_client/parser/__init__.py
@@ -14,6 +14,7 @@ Institute for Biomedical Research and Pelkmans Lab from the University of
 Zurich.
 """
 
+from ._auth import add_auth_parser
 from ._dataset import add_dataset_parser
 from ._job import add_job_parser
 from ._main import get_main_parser
@@ -41,3 +42,4 @@ add_usergroup_parser(subparsers_main)
 add_resource_parser(subparsers_main)
 add_profile_parser(subparsers_main)
 add_template_parser(subparsers_main)
+add_auth_parser(subparsers_main)

--- a/src/fractal_client/parser/_auth.py
+++ b/src/fractal_client/parser/_auth.py
@@ -1,0 +1,30 @@
+def add_auth_parser(subparsers):
+    auth_parser = subparsers.add_parser(
+        "auth",
+        description="Authentication commands.",
+        allow_abbrev=False,
+    )
+    auth_subparsers = auth_parser.add_subparsers(
+        title="Valid sub-commands", dest="subcmd", required=True
+    )
+
+    check_token_parser = auth_subparsers.add_parser(  # noqa: F841
+        "check-token",
+        description="Check whether a valid token is available.",
+        allow_abbrev=False,
+    )
+
+    set_token_parser = auth_subparsers.add_parser(  # noqa: F841
+        "set-token",
+        description=(
+            "Write a valid token to disk (using the default path or "
+            "the user-provided `--token-path` one)."
+        ),
+        allow_abbrev=False,
+    )
+
+    clear_token_parser = auth_subparsers.add_parser(  # noqa: F841
+        "clear-token",
+        description="Remove the file storing the token, if valid.",
+        allow_abbrev=False,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def override_settings(monkeypatch, tmp_path):
     import fractal_client.config
 
     def _override_settings(
-        FRACTAL_CACHE_PATH=str(tmp_path),
+        FRACTAL_CACHE_PATH=str(tmp_path / "cache"),
         FRACTAL_USER=None,
         FRACTAL_PASSWORD=None,
         FRACTAL_SERVER=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,7 @@ def override_settings(monkeypatch, tmp_path):
             "FRACTAL_CACHE_PATH",
             FRACTAL_CACHE_PATH,
         )
+        Path(FRACTAL_CACHE_PATH).mkdir(exist_ok=True, parents=True)
         monkeypatch.setattr(
             fractal_client.config.settings,
             "FRACTAL_USER",

--- a/tests/test_auth_command.py
+++ b/tests/test_auth_command.py
@@ -55,8 +55,13 @@ def test_auth_commands(
         (custom_token_path, settings.default_token_path),
     ):
         assert not Path(token_path).exists()
+
         with pytest.raises(SystemExit, match="not found"):
             invoke(f"{option} auth check-token")
+
+        res = invoke(f"{option} auth clear-token")
+        assert res.retcode == 1
+        assert "not found" in res.data
 
         monkeypatch.setattr("sys.stdin", io.StringIO(invalid_token))
         res = invoke(f"{option} auth set-token")
@@ -78,17 +83,12 @@ def test_auth_commands(
         assert res.retcode == 0
         assert "Removed" in res.data
 
-        res = invoke(f"{option} auth clear-token")
-        assert res.retcode == 1
-        assert "not found" in res.data
-
         monkeypatch.setattr("sys.stdin", io.StringIO(partially_valid_token))
         res = invoke(f"{option} auth set-token")
         assert res.retcode == 0
         assert "Token written" in res.data
         assert Path(token_path).exists()
 
-        # with pytest.raises(SystemExit)
         res = invoke(f"{option} auth check-token")
         assert res.retcode == 1
         assert "Token verification failed." in res.data

--- a/tests/test_auth_command.py
+++ b/tests/test_auth_command.py
@@ -1,0 +1,94 @@
+import io
+from datetime import datetime
+from datetime import timedelta
+from pathlib import Path
+
+import jwt
+import pytest
+
+from fractal_client.auth._args import AuthInfo
+from fractal_client.auth._client import AuthClient
+from fractal_client.config import settings
+
+
+@pytest.fixture(scope="function")
+def valid_token(tester) -> str:
+    from fractal_client.auth._token_utils import _is_token_valid
+
+    with AuthClient(
+        fractal_server="http://localhost:8765",
+        auth_info=AuthInfo(
+            user=tester["email"],
+            password=tester["password"],
+            token_path=None,
+        ),
+    ) as client:
+        token = client.token
+        assert _is_token_valid(token)
+    return token
+
+
+def test_auth_commands(
+    invoke,
+    monkeypatch,
+    tmp_path: Path,
+    valid_token: str,
+    override_settings,
+    tester: dict,
+):
+    override_settings()
+    custom_token_path = (tmp_path / "custom_token.txt").as_posix()
+
+    # Fully invalid token
+    invalid_token = "not-a-token"
+
+    # Partially valid token: it is a valid and not-expiring JWT token, but its signature
+    # is based on a key different from the fractal-server one.
+    partially_valid_token = jwt.encode(
+        payload={"exp": (datetime.now() + timedelta(days=1)).timestamp()},
+        key="some-long-jwt-secret-key-which-should-be-long",
+        algorithm="HS256",
+    )
+
+    for option, token_path in zip(
+        (f"--token-path {custom_token_path}", ""),
+        (custom_token_path, settings.default_token_path),
+    ):
+        assert not Path(token_path).exists()
+        with pytest.raises(SystemExit, match="not found"):
+            invoke(f"{option} auth check-token")
+
+        monkeypatch.setattr("sys.stdin", io.StringIO(invalid_token))
+        res = invoke(f"{option} auth set-token")
+        assert res.retcode == 1
+        assert "invalid" in res.data
+        assert not Path(token_path).exists()
+
+        monkeypatch.setattr("sys.stdin", io.StringIO(valid_token))
+        res = invoke(f"{option} auth set-token")
+        assert res.retcode == 0
+        assert "Token written" in res.data
+        assert Path(token_path).exists()
+
+        res = invoke(f"{option} auth check-token")
+        assert f"Valid token for {tester['email']}" in res.data
+        assert res.retcode == 0
+
+        res = invoke(f"{option} auth clear-token")
+        assert res.retcode == 0
+        assert "Removed" in res.data
+
+        res = invoke(f"{option} auth clear-token")
+        assert res.retcode == 1
+        assert "not found" in res.data
+
+        monkeypatch.setattr("sys.stdin", io.StringIO(partially_valid_token))
+        res = invoke(f"{option} auth set-token")
+        assert res.retcode == 0
+        assert "Token written" in res.data
+        assert Path(token_path).exists()
+
+        # with pytest.raises(SystemExit)
+        res = invoke(f"{option} auth check-token")
+        assert res.retcode == 1
+        assert "Token verification failed." in res.data

--- a/tests/test_invalid_commands.py
+++ b/tests/test_invalid_commands.py
@@ -1,6 +1,7 @@
 import pytest
 
 from fractal_client.cmd import NoCommandError
+from fractal_client.cmd import auth
 from fractal_client.cmd import dataset
 from fractal_client.cmd import group
 from fractal_client.cmd import job
@@ -27,6 +28,7 @@ def test_invalid_commands(invoke):
             "resource",
             "profile",
             "template",
+            "auth",
         ]:
             with pytest.raises(SystemExit):
                 invoke(f"{command}{arg}")
@@ -44,6 +46,7 @@ def test_unit_invalid_subcommand():
         resource,
         profile,
         template,
+        auth,
     ]:
         with pytest.raises(NoCommandError):
             _function(client=None, subcmd="invalid")


### PR DESCRIPTION
This introduces new commands like
```console
$ export FRACTAL_SERVER=https://fractal.example.org/backend

$ export FRACTAL_WEB=https://fractal.example.org

$ uv run fractal auth check-token
File not found at /home/user/.cache/fractal/token.txt

$ uv run fractal --token-path /tmp/token auth check-token
File not found at /tmp/token

$ uv run fractal --token-path /tmp/token auth set-token

Paste a valid token here (you can find it at https://fractal.example.org/profile/token), and it will be written to /tmp/token: ey[redacted]

$ uv run fractal --token-path /tmp/token auth check-token
Valid token for name.surname@example.org found at /tmp/token

$ uv run fractal --token-path /tmp/token auth clear-token
Removed /tmp/token.

$ uv run fractal --token-path /tmp/token auth check-token
File not found at /tmp/token
```


## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
